### PR TITLE
No warning for unused variables

### DIFF
--- a/src/STP/Core/Layer.cpp
+++ b/src/STP/Core/Layer.cpp
@@ -87,7 +87,7 @@ void Layer::SetOpacity(float opacity) {
     }
 }
 
-void Layer::draw(sf::RenderTarget& target, sf::RenderStates states) const {
+void Layer::draw(sf::RenderTarget& target, sf::RenderStates /* states */) const {
     if (visible) {
         for (unsigned int i = 0; i < tiles_.size(); ++i)
             target.draw(tiles_[i]);

--- a/src/STP/Core/ObjectGroup.cpp
+++ b/src/STP/Core/ObjectGroup.cpp
@@ -69,7 +69,7 @@ void ObjectGroup::SetColor(const sf::Color& color) {
     }
 }
 
-void ObjectGroup::draw(sf::RenderTarget& target, sf::RenderStates states) const {
+void ObjectGroup::draw(sf::RenderTarget& target, sf::RenderStates /* states */) const {
     if (visible) {
         for (unsigned int i = 0; i < objects_.size(); ++i)
             target.draw(objects_[i]);

--- a/src/STP/Core/TileMap.cpp
+++ b/src/STP/Core/TileMap.cpp
@@ -149,7 +149,7 @@ const std::string& TileMap::GetOrientation() const {
     return orientation_;
 }
 
-void TileMap::draw(sf::RenderTarget& target, sf::RenderStates states) const {
+void TileMap::draw(sf::RenderTarget& target, sf::RenderStates /* states */) const {
     for (unsigned int i = 0; i < map_objects_.size(); ++i) {
         if (map_objects_[i]->visible == true)
             target.draw(*map_objects_[i]);


### PR DESCRIPTION
When compiling under high warning levels, I get this warning for unused variables. I commented them out, which is AFAIK the usual thing to do.