### PR TITLE
Improve using this library as a cmake subproject

### DIFF
--- a/extlibs/CMakeLists.txt
+++ b/extlibs/CMakeLists.txt
@@ -9,21 +9,29 @@ set(ZLIB_DIR "${DEPENDENCIES_DIR}/zlib")
 
 # Find SFML
 set(SFML_ROOT ${SFML_DIR})
-find_package(SFML 2 COMPONENTS graphics window system)
-if(SFML_FOUND OR (SFML_INCLUDE_DIR AND SFML_LIBRARIES))
-    set(SFML_LIBRARIES ${SFML_LIBRARIES})
-elseif(SFML_SOURCE_DIR AND SFML_BINARY_DIR)
-    set(SFML_INCLUDE_DIR "${SFML_SOURCE_DIR}/include")
-    set(SFML_LIBRARIES "${SFML_BINARY_DIR}")
+if(!STP_SHARED_LIBS)
+    add_definitions(-DSFML_STATIC)
+endif()
+if (SFML_INCLUDE_DIR)
+    set(SFML_LIBRARIES sfml-graphics sfml-window sfml-system)
 else()
-    message("\n-> SFML directory not found. Put the SFML's top-level path "
-            "(containing \"include\" and \"lib\" directories) in the "
-            "/extlibs/SFML folder.\n")
+    find_package(SFML 2 COMPONENTS graphics window system)
+    if(SFML_FOUND)
+        # Nothing to do, already there
+    elseif(SFML_SOURCE_DIR AND SFML_BINARY_DIR)
+        set(SFML_INCLUDE_DIR "${SFML_SOURCE_DIR}/include")
+        set(SFML_LIBRARIES sfml-graphics sfml-window sfml-system)
+    else()
+        message("\n-> SFML directory not found. Put the SFML's top-level path "
+                "(containing \"include\" and \"lib\" directories) in the "
+                "/extlibs/SFML folder.\n")
+    endif()
 endif()
 
+
 # PUGIXML
-find_package(PugiXML REQUIRED)
-if (PugiXML_FOUND AND USE_SHARED_PUGIXML)
+if (USE_SHARED_PUGIXML)
+    find_package(PugiXML REQUIRED)
     set(PUGIXML_INCLUDE_DIR ${PUGIXML_INCLUDE_DIR})
     set(PUGIXML_LIBRARIES ${PUGIXML_LIBRARY})
 else()
@@ -48,7 +56,11 @@ else()
         "${TEMP_DIR}/zlib"
         "${ZLIB_DIR}"
     )
-    set(ZLIB_LIBRARIES zlib)
+    if(STP_SHARED_LIBS)
+        set(ZLIB_LIBRARIES zlib)
+    else()
+        set(ZLIB_LIBRARIES zlibstatic)
+    endif()
     set(COMPILED_DEPENDENCIES ${COMPILED_DEPENDENCIES} ${ZLIB_LIBRARIES})
 endif()
 

--- a/extlibs/CMakeLists.txt
+++ b/extlibs/CMakeLists.txt
@@ -11,8 +11,10 @@ set(ZLIB_DIR "${DEPENDENCIES_DIR}/zlib")
 set(SFML_ROOT ${SFML_DIR})
 find_package(SFML 2 COMPONENTS graphics window system)
 if(SFML_FOUND OR (SFML_INCLUDE_DIR AND SFML_LIBRARIES))
-    set(SFML_INCLUDE_DIR ${SFML_INCLUDE_DIR})
     set(SFML_LIBRARIES ${SFML_LIBRARIES})
+elseif(SFML_SOURCE_DIR AND SFML_BINARY_DIR)
+    set(SFML_INCLUDE_DIR "${SFML_SOURCE_DIR}/include")
+    set(SFML_LIBRARIES "${SFML_BINARY_DIR}")
 else()
     message("\n-> SFML directory not found. Put the SFML's top-level path "
             "(containing \"include\" and \"lib\" directories) in the "
@@ -20,8 +22,8 @@ else()
 endif()
 
 # PUGIXML
-if (USE_SHARED_PUGIXML)
-    find_package(PugiXML REQUIRED)
+find_package(PugiXML REQUIRED)
+if (PugiXML_FOUND AND USE_SHARED_PUGIXML)
     set(PUGIXML_INCLUDE_DIR ${PUGIXML_INCLUDE_DIR})
     set(PUGIXML_LIBRARIES ${PUGIXML_LIBRARY})
 else()

--- a/src/STP/Core/Layer.cpp
+++ b/src/STP/Core/Layer.cpp
@@ -26,6 +26,7 @@
 
 #include "STP/Core/Layer.hpp"
 
+#include <cstdio>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/src/STP/Core/Parser.cpp
+++ b/src/STP/Core/Parser.cpp
@@ -27,6 +27,7 @@
 #include "Parser.hpp"
 
 #include <cstring>
+#include <cstdio>
 
 #include <string>
 #include <sstream>

--- a/src/STP/Core/TileSet.cpp
+++ b/src/STP/Core/TileSet.cpp
@@ -26,6 +26,7 @@
 
 #include "STP/Core/TileSet.hpp"
 
+#include <cstdio>
 #include <stdexcept>
 #include <cmath>
 #include <string>


### PR DESCRIPTION
This PR improves including this library as a cmake subproject. It allows using a provided cmake subproject SFML (checked out as a submodule alongside STP). It also allows to compile and link it as a static lib. Finally it fixes some issue with building in cygwin as a subproject.