### PR TITLE
Support for hexagonal maps

### DIFF
--- a/src/STP/Core/Layer.cpp
+++ b/src/STP/Core/Layer.cpp
@@ -125,14 +125,20 @@ Layer::Tile::Tile(unsigned int gid, sf::IntRect tile_rect, std::string orientati
         }
 
         if (orientation == "staggered") {
-            if ((y % 2) == 0) {
-                tile_rect_.left = x * tile_rect_.width;
-            }
-            else {
-                tile_rect_.left = x * tile_rect_.width + tile_rect_.width /2;
-            }
-            tile_rect_.top = y * tile_rect_.height / 2;
+            tile_rect_.left = (x + (y & 1) * 0.5) * tile_rect_.width;
+            tile_rect_.top = y * tile_rect_.height * 0.5;
         }
+
+        if (orientation == "hexagonal") {
+            tile_rect_.left = (x + (y & 1) * 0.5) * tile_rect_.width;
+            tile_rect_.top = y * tile_rect_.height * 0.75;
+        }
+
+        tile_rect_.left += tileset->GetTileOffSet().x;
+        tile_rect_.top += tileset->GetTileOffSet().y;
+
+        // Tiles larger than the grid are drawn aligned on the base vertically
+        tile_rect_.top -= tileset->GetTileHeight() - tile_rect_.height;
     }
     else if (tile_rect_.width == 0 || tile_rect_.height == 0)
     {

--- a/src/STP/Core/Parser.cpp
+++ b/src/STP/Core/Parser.cpp
@@ -108,8 +108,6 @@ void Parser::AddTileToLayer(tmx::Layer* layer, int gid, sf::Vector2i tile_pos, t
     tmx::TileSet* tileset = tilemap->GetTileSet(gid);
 
     if (tileset != nullptr) {
-        tile_pos.x += tileset->GetTileOffSet().x;
-        tile_pos.y += tileset->GetTileOffSet().y;
         sf::IntRect tile_rect(tile_pos.x, tile_pos.y, tilemap->GetTileWidth(), tilemap->GetTileHeight());
         layer->AddTile(gid, tile_rect, tileset);
     } else {


### PR DESCRIPTION
This PR implements support for hexagonal maps. It also makes them (and other non hexagonal maps) render exactly as they look in tiled by using the offsets correctly.