### PR TITLE
Fixed SIGSEGV when reading properties on a tile that doesn't have any

### DIFF
--- a/src/STP/Core/Layer.cpp
+++ b/src/STP/Core/Layer.cpp
@@ -192,6 +192,8 @@ void Layer::Tile::AddProperty(const std::string& name, const std::string& value)
 }
 
 std::string& Layer::Tile::GetPropertyValue(const std::string& name) {
+    if(tile_properties_==nullptr)
+        tile_properties=new tmx::Properties();
     return tile_properties_->GetPropertyValue(name);
 }
 

--- a/src/STP/Core/Layer.cpp
+++ b/src/STP/Core/Layer.cpp
@@ -193,7 +193,7 @@ void Layer::Tile::AddProperty(const std::string& name, const std::string& value)
 
 std::string& Layer::Tile::GetPropertyValue(const std::string& name) {
     if(tile_properties_==nullptr)
-        tile_properties=new tmx::Properties();
+        tile_properties_=new tmx::Properties();
     return tile_properties_->GetPropertyValue(name);
 }
 


### PR DESCRIPTION
Look at the commit comment.